### PR TITLE
Custom validation of histogram plot colors

### DIFF
--- a/R/customizedRCircos.R
+++ b/R/customizedRCircos.R
@@ -69,7 +69,7 @@ PACVr.Histogram.Plot <- function(hist.data = NULL,
   locations <- PACVr.Get.Start.End.Locations(hist.data, RCircos.Par$hist.width)
 
   # Histgram colors and height
-  histColors <- RCircos::RCircos.Get.Plot.Colors(hist.data, RCircos.Par$hist.color)
+  histColors <- RCircos::RCircos.Get.Plot.Colors(hist.data, RCircos.Par$hist.colors)
   histValues <- as.numeric(hist.data[, data.col])
   if (is.null(max.value) || is.null(min.value)) {
     max.value <- max(histValues)

--- a/R/customizedRCircos.R
+++ b/R/customizedRCircos.R
@@ -476,6 +476,10 @@ PACVr.Reset.Plot.Parameters <- function (new.params = NULL)
   #   ==========================================================
 
   RCircos::RCircos.Validate.Plot.Parameters(new.params)
+  if (!is.null(new.params$hist.colors)) 
+  {
+    validateColors(new.params$hist.colors)
+  }
   
   #   4.  Parameters related to ideogram width change.
   #       Note: chr.ideo.pos is a read-only parameter

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -427,3 +427,11 @@ checkIREquality <- function(gbkData, regions, dir, sample_name) {
     )
   }
 }
+
+validateColors <- function(colorsToValidate) {
+  colorNames <- colors()
+  unsupportedColors <- colorsToValidate[!(colorsToValidate %in% colorNames)]
+  if (length(unsupportedColors) > 0) {
+    stop("Unsupported R plot color defined.")
+  }
+}

--- a/R/visualizeWithRCircos.R
+++ b/R/visualizeWithRCircos.R
@@ -79,11 +79,7 @@ visualizeWithRCircos <- function(plotTitle,
   RCircosEnvironment.params$track.out.start <- 1.5
   RCircosEnvironment.params$radius.len <- 3
   PACVr.Reset.Plot.Parameters(RCircosEnvironment.params)
-  RCircosEnvironment.cyto <- RCircos::RCircos.Get.Plot.Ideogram()  
-  # The above lines causes message:
-  #Warning message:
-  #  In !parameters$text.color %in% colorNames || !parameters$hist.color %in%  :
-  #  'length(x) = 644 > 1' in coercion to 'logical(1)'
+  RCircosEnvironment.cyto <- RCircos::RCircos.Get.Plot.Ideogram()
     })
   })
   

--- a/R/visualizeWithRCircos.R
+++ b/R/visualizeWithRCircos.R
@@ -72,7 +72,7 @@ visualizeWithRCircos <- function(plotTitle,
   # TO DO - Please check why the below lines produce the warning message:
   suppressMessages({
     suppressWarnings({
-  RCircosEnvironment.params$hist.color <- HistCol(coverage, threshold, relative, logScale)
+  RCircosEnvironment.params$hist.colors <- HistCol(coverage, threshold, relative, logScale)
   RCircosEnvironment.params$line.color <- "yellow3"
   RCircosEnvironment.params$chrom.width <- 0.05
   RCircosEnvironment.params$track.in.start <- 1.08


### PR DESCRIPTION
As currently defined, `RCircos.Validate.Plot.Parameters()` expects `parameters$hist.color` to be a single string that can be validated against and not a vector of strings. Right now this validation can be bypassed by just renaming the variable where it is used. I did add an equivalent validation for testing this vector of colors in the same way as performed for `RCircos.Validate.Plot.Parameters()` .