### PR TITLE
Version 1.0.7 changes documentation & GitHub action workflow for automated releases

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,4 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^tests/
+^\.github/

--- a/.github/scripts/update_version_tag.py
+++ b/.github/scripts/update_version_tag.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import re
+
+
+def main():
+    r_directory = "../../R/"
+    current_timestamp = sys.argv[1]
+    version_comment = f"#version=\"{current_timestamp}\"\n"
+
+    for filename in os.listdir(r_directory):
+        file_path = os.path.join(r_directory, filename)
+
+        if os.path.isfile(file_path):
+            with open(file_path, 'r') as file:
+                lines = file.readlines()
+
+            if len(lines) >= 4 and re.match("^#version", lines[3]):
+                lines[3] = version_comment
+                with open(file_path, 'w') as file:
+                    file.writelines(lines)
+                    print(f"Version comment updated to current UTC: {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,8 +3,14 @@
 on:
   push:
     branches: [main, master]
+    paths:
+      - "R/**"
+      - "tests/**"
   pull_request:
     branches: [main, master]
+    paths:
+      - "R/**"
+      - "tests/**"
 
 name: R-CMD-check
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,155 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["CHANGELOG.md"]
+
+name: create-release
+
+jobs:
+  release-documentation:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CHANGELOG: "CHANGELOG.md"
+      DESCRIPTION: "DESCRIPTION"
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract release version from first level 4 heading
+        id: extract-version
+        run: |
+          version=$(grep -oP '####[^0-9]*\K\d+\.\d+\.\d+' -m 1 $CHANGELOG)
+          echo "version=$version" >> $GITHUB_ENV
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Version: $version"
+
+      - name: Get current UTC timestamp
+        id: get-timestamp
+        run: |
+          timestamp=$(date -u +"%Y.%m.%d.%H%M")
+          echo "timestamp=$timestamp" >> $GITHUB_ENV
+          echo "Timestamp: $timestamp"
+
+      - name: Standardize first level 4 heading
+        id: update-change-header
+        run: |
+          timestamp=$(echo "${{ env.timestamp }}" | awk -F'.' '{print $1"."$2"."$3}')
+          sed -i "0,/^####.*$/s/^####.*$/#### Version ${{ env.version }} \($timestamp\)/" $CHANGELOG
+          echo "CHANGELOG Timestamp: $timestamp"
+
+      - name: Update DESCRIPTION `Version` and `Date`
+        id: update-description
+        run: |
+          timestamp=$(echo "${{ env.timestamp }}" | awk -F'.' '{print $1"-"$2"-"$3}')
+          sed -i "s|^Date:.*$|Date: $timestamp|" $DESCRIPTION
+          sed -i "s|^Version:.*$|Version: ${{ env.version }}|" $DESCRIPTION
+          echo "DESCRIPTION Timestamp: $timestamp"
+
+      - name: Update `version` comments on R files
+        id: update-r-version-comment
+        run: |
+          cd .github/scripts
+          chmod +x update_version_tag.py
+          python update_version_tag.py ${{ env.timestamp }}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add ./R/*.R
+          git add DESCRIPTION
+          git add CHANGELOG.md
+          git commit -m "Updated documentation for release" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin
+
+  release-build:
+    runs-on: ubuntu-latest
+    needs: release-documentation
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CHANGELOG: "CHANGELOG.md"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-tinytex@v2
+      - run: tlmgr --version
+
+      - name: Install additional LaTeX packages
+        run: |
+          tlmgr install preprint
+          tlmgr install listings
+          tlmgr install tcolorbox
+          tlmgr install pgf
+          tlmgr install environ
+          tlmgr install tikzfill
+          tlmgr install pdfcol
+          tlmgr install grfext
+          tlmgr list --only-installed
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "release"
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Build R package
+        run: |
+          R CMD build --compact-vignettes=gs+qpdf .
+          tar_file="$(find . -maxdepth 1 -type f -name '*.tar.gz' -print -quit | sed 's|^\./||')"
+          artifacts="artifacts"
+          mkdir $artifacts
+          mv $tar_file "$artifacts/"
+          echo "tar_file=$artifacts/$tar_file" >> $GITHUB_ENV
+          echo "asset_name=$tar_file" >> $GITHUB_ENV
+
+      - name: Make release properties
+        id: release-fields
+        run: |
+          version="${{ needs.release-documentation.outputs.version }}"
+          echo "version=$version" >> $GITHUB_ENV
+          echo "Version: $version"
+          tag="v${version}"
+          echo "tag=$tag" >> $GITHUB_ENV
+          echo "Tag: $tag"
+          name="Version ${version}"
+          echo "name=$name" >> $GITHUB_ENV
+          echo "Name: $name"
+          body="$(awk '/^\*.*$/{print; next} /^####/{count++; if(count==2) exit}' $CHANGELOG)"
+          echo "body<<EOF" >> "$GITHUB_ENV"
+          echo "$body" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+          echo "Body: $body"
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.tag }}
+          release_name: ${{ env.name }}
+          draft: false
+          prerelease: false
+          body: |
+            ${{ env.body }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ${{ env.tar_file }}
+          asset_name: ${{ env.asset_name }}
+          asset_content_type: application/gzip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@ CHANGELOG
 ---------
 
 #### Version 1.0.7 (2024.01.25)
-* list by Greg here
+* More robust parsing of feature sequence locations using INSDC standards
+* Exception handling for attempted reading of GenBank data
+* "Repair" GenBank data with unqualified features to handle `read.gb` bug 
+* Preemptively checks for presence of data property necessary for specified analysis, 
+    with `logger` info in case of issues
 
 #### Version 1.0.6 (2024.01.07)
 * Moved functions reg. IRs, quadripartite structure into separate file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 ---------
 
-#### Version 1.0.7 (2024.01.25)
+#### Version 1.0.7 (2024.02.01)
 * More robust parsing of feature sequence locations using INSDC standards
 * Exception handling for attempted reading of GenBank data
 * "Repair" GenBank data with unqualified features to handle `read.gb` bug 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ CHANGELOG
 * More robust parsing of feature sequence locations using INSDC standards
 * Exception handling for attempted reading of GenBank data
 * "Repair" GenBank data with unqualified features to handle `read.gb` bug 
-* Preemptively checks for presence of data property necessary for specified analysis, 
-    with `logger` info in case of issues
+* Preemptively checks for presence of data property necessary for specified analysis, with `logger` info in case of issues
 
 #### Version 1.0.6 (2024.01.07)
 * Moved functions reg. IRs, quadripartite structure into separate file

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PACVr
 Version: 1.0.7
-Date: 2024-01-25
+Date: 2024-02-01
 Title: Plastome Assembly Coverage Visualization
 Authors@R: c(person("Gregory", "Smith", role=c("ctb")),
              person("Nils", "Jenke", role=c("ctb")),

--- a/R/IRoperations.R
+++ b/R/IRoperations.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 checkIREquality <- function(gbkData, regions, dir, sample_name) {
   gbkSeq <- read.gbSeq(gbkData)

--- a/R/IRoperations.R
+++ b/R/IRoperations.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 checkIREquality <- function(gbkData, regions, dir, sample_name) {
   gbkSeq <- read.gbSeq(gbkData)

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 PACVr.read.gb <- function(gbkFile) {
   gbkRaw <- getGbkRaw(gbkFile)

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 PACVr.read.gb <- function(gbkFile) {
   gbkRaw <- getGbkRaw(gbkFile)

--- a/R/customizedRCircos.R
+++ b/R/customizedRCircos.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 
 # The following R functions were taken from the R package RCircos and then modified.

--- a/R/customizedRCircos.R
+++ b/R/customizedRCircos.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 
 # The following R functions were taken from the R package RCircos and then modified.

--- a/R/customizedRead.gb.R
+++ b/R/customizedRead.gb.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 read.gbWithHandling <- function(gbkRaw, count=0) {
   gbkData <- tryCatch({

--- a/R/customizedRead.gb.R
+++ b/R/customizedRead.gb.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 read.gbWithHandling <- function(gbkRaw, count=0) {
   gbkData <- tryCatch({

--- a/R/generatePlotData.R
+++ b/R/generatePlotData.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 CovCalc <- function(bamFile, windowSize = 250) {
   # Calculates coverage of a given bam file and stores data in data.frame format

--- a/R/generatePlotData.R
+++ b/R/generatePlotData.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 CovCalc <- function(bamFile, windowSize = 250) {
   # Calculates coverage of a given bam file and stores data in data.frame format

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 read.gb2DF <- function(gbkData, regionsCheck) {
   fileDF <- data.frame()

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 read.gb2DF <- function(gbkData, regionsCheck) {
   fileDF <- data.frame()

--- a/R/parseData.R
+++ b/R/parseData.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 ExtractAllGenes <- function(gbkDataDF) {
   # Function to extract gene information from Genbank flatfile data

--- a/R/parseData.R
+++ b/R/parseData.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 ExtractAllGenes <- function(gbkDataDF) {
   # Function to extract gene information from Genbank flatfile data

--- a/R/quadripartiteOperations.R
+++ b/R/quadripartiteOperations.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 FilterByKeywords <- function(allRegions, where) {
   # Function to filter list based on genomic keywords

--- a/R/quadripartiteOperations.R
+++ b/R/quadripartiteOperations.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 FilterByKeywords <- function(allRegions, where) {
   # Function to filter list based on genomic keywords

--- a/R/visualizeWithRCircos.R
+++ b/R/visualizeWithRCircos.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.01.25.1500"
+#version="2024.02.01.0316"
 
 visualizeWithRCircos <- function(plotTitle,
                                  genes,

--- a/R/visualizeWithRCircos.R
+++ b/R/visualizeWithRCircos.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.01.0316"
+#version="2024.02.01.0322"
 
 visualizeWithRCircos <- function(plotTitle,
                                  genes,


### PR DESCRIPTION
The only change to the normal repo items is to `CHANGELOG.md` and summarize the changes since version `1.0.6`.

Added is a custom workflow that automates releases to the repo when changes are performed on `CHANGELOG.md`. In summary, the most recent version change listed (the first `####` header encountered) in combination with the current UTC timestamp are used to update version and date information in `DESCRIPTION`, core R files (those in `R/`) that have a `#version` comment, and also in `CHANGELOG.md` to make sure the version and timestamp are the same everywhere. After this, PACVr is built with `R CMD build`, and added as a release asset, in addition to the standard repo source code assets. The default "body" text of the release is that of the details corresponding to this version (the unordered list specified by `*`s following the first `####` header).

TL;DR
If you add a new version and related description to `CHANGELOG.md`, all timestamps will be updated to "now", and all mentions of the package version will reflect this stated version. After this happens, a release will be created corresponding to this version, which will include an R source package reflecting the current state of the repo.