### PR TITLE
Refactor of `PACVr.complete`; decoding `IRCheck` as a single variable; handle use of `note` qualifier for IR name

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,6 @@ on:
     paths: ["tests/**"]
   pull_request:
     branches: [main, master]
-    paths: ["tests/**"]
 
 name: R-CMD-check
 

--- a/.github/workflows/dos2unix.yaml
+++ b/.github/workflows/dos2unix.yaml
@@ -3,6 +3,8 @@
 on:
   push:
     paths: ["R/**"]
+  pull_request:
+    paths: ["R/**"]
 
 name: dos2unix
 

--- a/.github/workflows/dos2unix.yaml
+++ b/.github/workflows/dos2unix.yaml
@@ -3,8 +3,6 @@
 on:
   push:
     paths: ["R/**"]
-  pull_request:
-    paths: ["R/**"]
 
 name: dos2unix
 

--- a/R/IRoperations.R
+++ b/R/IRoperations.R
@@ -158,7 +158,7 @@ plotIRLinks <- function(linkData, syntenyLineType) {
   }
 }
 
-isSyntenyLineType <- function(syntenyLineType) {
+getIsSyntenyLine <- function(syntenyLineType) {
   syntenyLineTypes <- c(1, 2)
   return(syntenyLineType %in% syntenyLineTypes)
 }

--- a/R/IRoperations.R
+++ b/R/IRoperations.R
@@ -158,7 +158,10 @@ plotIRLinks <- function(linkData, syntenyLineType) {
   }
 }
 
-getIsSyntenyLine <- function(syntenyLineType) {
+getSyntenyLineType <- function(IRCheck) {
   syntenyLineTypes <- c(1, 2)
-  return(syntenyLineType %in% syntenyLineTypes)
+  if (IRCheck %in% syntenyLineTypes) {
+    return(IRCheck)
+  }
+  return(NULL)
 }

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -108,7 +108,7 @@ PACVr.quadripRegions <- function(gbkData,
     quadripRegions <- PACVr.parseQuadripRegions(gbkData,
                                                 gbkDataDF)
   } else {
-    quadripRegions <- PACVr.parseQuadripRegions(gbkDataDF)
+    quadripRegions <- PACVr.parseSource(gbkDataDF)
   }
   return(quadripRegions)
 }

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -57,7 +57,7 @@ PACVr.verboseInformation <- function(gbkData,
                                      quadripRegions,
                                      analysisSpecs,
                                      output) {
-  if (analysisSpecs["isIRCheck"]) {
+  if (analysisSpecs$isIRCheck) {
     logger::log_info('Generating statistical information on the sequencing coverage')
     verboseInformation(gbkData,
                        bamFile,
@@ -192,7 +192,7 @@ PACVr.complete <- function(gbkFile,
   gbkData <- PACVr.read.gb(gbkFile)
   analysisSpecs <- getAnalysisSpecs(IRCheck)
   gbkDataDF <- read.gb2DF(gbkData,
-                          analysisSpecs["isIRCheck"])
+                          analysisSpecs$isIRCheck)
   if (is.null(gbkDataDF)) {
     logger::log_error(paste("No usable data to perform specified analysis"))
     return(NULL)
@@ -201,7 +201,7 @@ PACVr.complete <- function(gbkFile,
   ###################################
   quadripRegions <- PACVr.quadripRegions(gbkData,
                                          gbkDataDF,
-                                         analysisSpecs["isIRCheck"])
+                                         analysisSpecs$isIRCheck)
 
   ###################################
   genes <- PACVr.parseGenes(gbkDataDF)
@@ -213,7 +213,7 @@ PACVr.complete <- function(gbkFile,
   ###################################
   linkData <- PACVr.linkData(genes,
                              quadripRegions,
-                             analysisSpecs["syntenyLineType"])
+                             analysisSpecs$syntenyLineType)
 
   ###################################
   if (verbose) {

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -28,12 +28,14 @@ PACVr.parseSource <- function(gbkDataDF) {
 
 PACVr.parseGenes <- function (gbkDataDF) {
   # This function parses the genes of a GenBank file
+  logger::log_info('Parsing the different genes')
   genes <- ExtractAllGenes(gbkDataDF)
   return(genes)
 }
 
 PACVr.calcCoverage <-
   function (bamFile, windowSize=250) {
+    logger::log_info('Calculating the sequencing coverage')
     coverage <- CovCalc(bamFile, windowSize)
     return(coverage)
   }
@@ -213,11 +215,9 @@ PACVr.complete <- function(gbkFile,
                                          isIRCheck)
 
   ###################################
-  logger::log_info('Parsing the different genes')
   genes <- PACVr.parseGenes(gbkDataDF)
 
   ###################################
-  logger::log_info('Calculating the sequencing coverage')
   coverage <- PACVr.calcCoverage(bamFile,
                                  windowSize)
 

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -126,14 +126,13 @@ PACVr.quadripRegions <- function(gbkData,
 
 PACVr.linkData <- function(genes,
                            quadripRegions,
-                           IRCheck) {
+                           syntenyLineType) {
   linkData <- NULL
-  isSyntenyLine <- getIsSyntenyLine(IRCheck)
-  if (isSyntenyLine) {
+  if (!is.null(syntenyLineType)) {
     logger::log_info('Inferring the IR regions and the genes within the IRs')
     linkData <- PACVr.generateIRGeneData(genes,
                                          quadripRegions,
-                                         IRCheck)
+                                         syntenyLineType)
   }
   return(linkData)
 }
@@ -202,8 +201,9 @@ PACVr.complete <- function(gbkFile,
                            output=NA) {
   ######################################################################
   gbkData <- PACVr.read.gb(gbkFile)
-  isIRCheck <- getIsIRCheck(IRCheck)
-  gbkDataDF <- read.gb2DF(gbkData, isIRCheck)
+  analysisSpecs <- getAnalysisSpecs(IRCheck)
+  gbkDataDF <- read.gb2DF(gbkData,
+                          analysisSpecs$isIRCheck)
   if (is.null(gbkDataDF)) {
     logger::log_error(paste("No usable data to perform specified analysis"))
     return(NULL)
@@ -212,7 +212,7 @@ PACVr.complete <- function(gbkFile,
   ###################################
   quadripRegions <- PACVr.quadripRegions(gbkData,
                                          gbkDataDF,
-                                         isIRCheck)
+                                         analysisSpecs$isIRCheck)
 
   ###################################
   genes <- PACVr.parseGenes(gbkDataDF)
@@ -224,17 +224,17 @@ PACVr.complete <- function(gbkFile,
   ###################################
   linkData <- PACVr.linkData(genes,
                              quadripRegions,
-                             IRCheck)
+                             analysisSpecs$syntenyLineType)
 
   ###################################
   if (isIRCheck && verbose) {
-      logger::log_info('Generating statistical information on the sequencing coverage')
-      PACVr.verboseInformation(gbkData,
-                               bamFile,
-                               genes,
-                               quadripRegions,
-                               IRCheck,
-                               output)
+    logger::log_info('Generating statistical information on the sequencing coverage')
+    PACVr.verboseInformation(gbkData,
+                             bamFile,
+                             genes,
+                             quadripRegions,
+                             !is.null(analysisSpecs$syntenyLineType),
+                             output)
   } else if (verbose) {
       logger::log_warn(paste0('Verbose output requires `IRCheck` in ',
                               '`', deparse(getIRCheckTypes()), '`'))

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -57,7 +57,7 @@ PACVr.verboseInformation <- function(gbkData,
                                      quadripRegions,
                                      analysisSpecs,
                                      output) {
-  if (analysisSpecs$isIRCheck) {
+  if (analysisSpecs["isIRCheck"]) {
     logger::log_info('Generating statistical information on the sequencing coverage')
     verboseInformation(gbkData,
                        bamFile,
@@ -192,7 +192,7 @@ PACVr.complete <- function(gbkFile,
   gbkData <- PACVr.read.gb(gbkFile)
   analysisSpecs <- getAnalysisSpecs(IRCheck)
   gbkDataDF <- read.gb2DF(gbkData,
-                          analysisSpecs$isIRCheck)
+                          analysisSpecs["isIRCheck"])
   if (is.null(gbkDataDF)) {
     logger::log_error(paste("No usable data to perform specified analysis"))
     return(NULL)
@@ -201,7 +201,7 @@ PACVr.complete <- function(gbkFile,
   ###################################
   quadripRegions <- PACVr.quadripRegions(gbkData,
                                          gbkDataDF,
-                                         analysisSpecs$isIRCheck)
+                                         analysisSpecs["isIRCheck"])
 
   ###################################
   genes <- PACVr.parseGenes(gbkDataDF)
@@ -213,7 +213,7 @@ PACVr.complete <- function(gbkFile,
   ###################################
   linkData <- PACVr.linkData(genes,
                              quadripRegions,
-                             analysisSpecs$syntenyLineType)
+                             analysisSpecs["syntenyLineType"])
 
   ###################################
   if (verbose) {

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -192,7 +192,7 @@ PACVr.complete <- function(gbkFile,
   gbkData <- PACVr.read.gb(gbkFile)
   analysisSpecs <- getAnalysisSpecs(IRCheck)
   gbkDataDF <- read.gb2DF(gbkData,
-                          analysisSpecs$isIRCheck)
+                          analysisSpecs)
   if (is.null(gbkDataDF)) {
     logger::log_error(paste("No usable data to perform specified analysis"))
     return(NULL)

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -200,8 +200,8 @@ PACVr.complete <- function(gbkFile,
 
   ###################################
   linkData <- NULL
-  IRCheck <- isSyntenyLineType(IRCheck)
-  if (IRCheck) {
+  isSyntenyLine <- getIsSyntenyLine(IRCheck)
+  if (isSyntenyLine) {
     logger::log_info('Inferring the IR regions and the genes within the IRs')
     linkData <- PACVr.generateIRGeneData(genes,
                                          quadripRegions,

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -109,6 +109,33 @@ PACVr.visualizeWithRCircos <- function(gbkData,
   )
 }
 
+PACVr.quadripRegions <- function(gbkData,
+                                 gbkDataDF,
+                                 isIRCheck) {
+  if (isIRCheck) {
+    logger::log_info('Parsing the different genome regions')
+    quadripRegions <- PACVr.parseQuadripRegions(gbkData,
+                                                gbkDataDF)
+  } else {
+    quadripRegions <- PACVr.parseQuadripRegions(gbkDataDF)
+  }
+  return(quadripRegions)
+}
+
+PACVr.linkData <- function(genes,
+                           quadripRegions,
+                           IRCheck) {
+  linkData <- NULL
+  isSyntenyLine <- getIsSyntenyLine(IRCheck)
+  if (isSyntenyLine) {
+    logger::log_info('Inferring the IR regions and the genes within the IRs')
+    linkData <- PACVr.generateIRGeneData(genes,
+                                         quadripRegions,
+                                         IRCheck)
+  }
+  return(linkData)
+}
+
 #' @title Execute the complete pipeline of \pkg{PACVr}
 #' @description This function executes the complete pipeline of \pkg{PACVr} 
 #' via a single command.
@@ -181,13 +208,9 @@ PACVr.complete <- function(gbkFile,
   }
   
   ###################################
-  if (isIRCheck) {
-    logger::log_info('Parsing the different genome regions')
-    quadripRegions <- PACVr.parseQuadripRegions(gbkData,
-										 gbkDataDF)
-  } else {
-    quadripRegions <- PACVr.parseQuadripRegions(gbkDataDF)
-  }
+  quadripRegions <- PACVr.quadripRegions(gbkData,
+                                         gbkDataDF,
+                                         isIRCheck)
 
   ###################################
   logger::log_info('Parsing the different genes')
@@ -199,14 +222,9 @@ PACVr.complete <- function(gbkFile,
                                  windowSize)
 
   ###################################
-  linkData <- NULL
-  isSyntenyLine <- getIsSyntenyLine(IRCheck)
-  if (isSyntenyLine) {
-    logger::log_info('Inferring the IR regions and the genes within the IRs')
-    linkData <- PACVr.generateIRGeneData(genes,
-                                         quadripRegions,
-                                         IRCheck)
-  }
+  linkData <- PACVr.linkData(genes,
+                             quadripRegions,
+                             IRCheck)
 
   ###################################
   if (isIRCheck && verbose) {

--- a/R/PACVr.R
+++ b/R/PACVr.R
@@ -55,30 +55,19 @@ PACVr.verboseInformation <- function(gbkData,
                                      bamFile,
                                      genes,
                                      quadripRegions,
-                                     IRCheck,
+                                     analysisSpecs,
                                      output) {
-  sampleName <- read.gbSampleName(gbkData)
-  # Step 1. Check ...
-  if (!is.na(output)) {
-    outDir <- dirname(output)
-    tmpDir <- file.path(outDir, 
-            paste(sampleName["sample_name"],
-            ".tmp",
-            sep=""))
+  if (analysisSpecs$isIRCheck) {
+    logger::log_info('Generating statistical information on the sequencing coverage')
+    verboseInformation(gbkData,
+                       bamFile,
+                       genes,
+                       quadripRegions,
+                       analysisSpecs,
+                       output)
   } else {
-    tmpDir <-
-      file.path(".", paste(sampleName["sample_name"],
-                   ".tmp",
-                   sep=""))
-  }
-  # Step 2. Check ...
-  if (dir.exists(tmpDir) == FALSE) {
-    dir.create(tmpDir)
-  }
-  # Step 3. Write output
-  writeTables(quadripRegions, bamFile, genes, tmpDir, sampleName)
-  if (IRCheck) {
-    checkIREquality(gbkData, quadripRegions, tmpDir, sampleName)
+    logger::log_warn(paste0('Verbose output requires `IRCheck` in ',
+                            '`', deparse(getIRCheckTypes()), '`'))
   }
 }
 
@@ -227,17 +216,13 @@ PACVr.complete <- function(gbkFile,
                              analysisSpecs$syntenyLineType)
 
   ###################################
-  if (isIRCheck && verbose) {
-    logger::log_info('Generating statistical information on the sequencing coverage')
+  if (verbose) {
     PACVr.verboseInformation(gbkData,
                              bamFile,
                              genes,
                              quadripRegions,
-                             !is.null(analysisSpecs$syntenyLineType),
+                             analysisSpecs,
                              output)
-  } else if (verbose) {
-      logger::log_warn(paste0('Verbose output requires `IRCheck` in ',
-                              '`', deparse(getIRCheckTypes()), '`'))
   }
   
   ###################################

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -3,10 +3,10 @@
 #email="m_gruenstaeudl@fhsu.edu"
 #version="2024.02.01.1736"
 
-read.gb2DF <- function(gbkData, IRPresenceAndSyntenyCheck) {
+read.gb2DF <- function(gbkData, analysisSpecs) {
   fileDF <- data.frame()
   for (sample in gbkData) {
-    sampleDF <- parseFeatures(sample$FEATURES, IRPresenceAndSyntenyCheck)
+    sampleDF <- parseFeatures(sample$FEATURES, analysisSpecs)
     if (!is.null(sampleDF)) {
       fileDF <- dplyr::bind_rows(fileDF, sampleDF)
     }
@@ -18,7 +18,7 @@ read.gb2DF <- function(gbkData, IRPresenceAndSyntenyCheck) {
   return(fileDF)
 }
 
-parseFeatures <- function(features, IRPresenceAndSyntenyCheck) {
+parseFeatures <- function(features, analysisSpecs) {
   sampleDF <- data.frame()
   for (feature in features) {
     feature <- parseFeature(feature)
@@ -27,7 +27,7 @@ parseFeatures <- function(features, IRPresenceAndSyntenyCheck) {
     }
   }
   # check if can we can use the sample
-  subsetCols <- checkFeatureQualifiers(sampleDF, IRPresenceAndSyntenyCheck)
+  subsetCols <- checkFeatureQualifiers(sampleDF, analysisSpecs)
   if (is.null(subsetCols)) {
     return(NULL)
   }
@@ -372,9 +372,9 @@ validateColors <- function(colorsToValidate) {
   }
 }
 
-checkFeatureQualifiers <- function(sampleDF, IRPresenceAndSyntenyCheck) {
+checkFeatureQualifiers <- function(sampleDF, analysisSpecs) {
   subsetCols <- c("gene", "note", "type")
-  if (IRPresenceAndSyntenyCheck) {
+  if (analysisSpecs$isIRCheck) {
     subsetCols <- c(subsetCols, "standard_name")
   }
   missingCols <- subsetCols[!(subsetCols %in% colnames(sampleDF))]

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -370,7 +370,6 @@ validateColors <- function(colorsToValidate) {
 }
 
 checkFeatureQualifiers <- function(sampleDF, analysisSpecs) {
-  subsetCols <- getSubsetCols(analysisSpecs)
   subsetData <- getSubsetData(sampleDF, subsetCols, analysisSpecs)
   if (length(subsetData$missingCols) > 0) {
     logger::log_warn(paste0("Unable to analyze sample as specified; ",
@@ -394,6 +393,7 @@ getSubsetCols <- function(analysisSpecs) {
 }
 
 getSubsetData <- function(sampleDF, subsetCols, analysisSpecs) {
+  subsetCols <- getSubsetCols(analysisSpecs)
   missingCols <- subsetCols[!(subsetCols %in% colnames(sampleDF))]
   if (analysisSpecs$isIRCheck && ("standard_name" %in% missingCols)) {
     logger::log_info("Using `note` for IR name qualifier")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -430,7 +430,7 @@ verboseInformation <- function(gbkData,
   }
   # Step 3. Write output
   writeTables(quadripRegions, bamFile, genes, tmpDir, sampleName)
-  if (!is.null(analysisSpecs$syntenyLineType)) {
+  if (!is.null(analysisSpecs["syntenyLineType"])) {
     checkIREquality(gbkData, quadripRegions, tmpDir, sampleName)
   }
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -187,12 +187,9 @@ read.gbGenes <- function(gbkDataDF) {
 
 read.gbOther <- function(gbkDataDF) {
   type <- NULL
-  subsetCols <- c("seqnames", "start", "end", 
-                  "gene", "note", "standard_name")
   regions <- gbkDataDF %>%
               dplyr::filter(!type %in% c("gene", "exon", "transcript",
-                                  "CDS", "variant")) %>% 
-              dplyr::select(dplyr::all_of(subsetCols))
+                                  "CDS", "variant"))
   rownames(regions) <- NULL
   return(regions)
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -403,3 +403,34 @@ getAnalysisSpecs <- function(IRCheck) {
   )
   return(analysisSpecs)
 }
+
+verboseInformation <- function(gbkData,
+                               bamFile,
+                               genes,
+                               quadripRegions,
+                               analysisSpecs,
+                               output) {
+  sampleName <- read.gbSampleName(gbkData)
+  # Step 1. Check ...
+  if (!is.na(output)) {
+    outDir <- dirname(output)
+    tmpDir <- file.path(outDir,
+                        paste(sampleName["sample_name"],
+                              ".tmp",
+                              sep=""))
+  } else {
+    tmpDir <-
+      file.path(".", paste(sampleName["sample_name"],
+                           ".tmp",
+                           sep=""))
+  }
+  # Step 2. Check ...
+  if (dir.exists(tmpDir) == FALSE) {
+    dir.create(tmpDir)
+  }
+  # Step 3. Write output
+  writeTables(quadripRegions, bamFile, genes, tmpDir, sampleName)
+  if (!is.null(analysisSpecs$syntenyLineType)) {
+    checkIREquality(gbkData, quadripRegions, tmpDir, sampleName)
+  }
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -392,7 +392,7 @@ getSubsetCols <- function(analysisSpecs) {
   return(subsetCols)
 }
 
-getSubsetData <- function(sampleDF, subsetCols, analysisSpecs) {
+getSubsetData <- function(sampleDF, analysisSpecs) {
   subsetCols <- getSubsetCols(analysisSpecs)
   missingCols <- subsetCols[!(subsetCols %in% colnames(sampleDF))]
   if (analysisSpecs$isIRCheck && ("standard_name" %in% missingCols)) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -397,7 +397,7 @@ isIgnoredFeature <- function(featureName) {
 }
 
 getAnalysisSpecs <- function(IRCheck) {
-  analysisSpecs <- c(
+  analysisSpecs <- list(
     syntenyLineType = getSyntenyLineType(IRCheck),
     isIRCheck = getIsIRCheck(IRCheck)
   )
@@ -430,7 +430,7 @@ verboseInformation <- function(gbkData,
   }
   # Step 3. Write output
   writeTables(quadripRegions, bamFile, genes, tmpDir, sampleName)
-  if (!is.null(analysisSpecs["syntenyLineType"])) {
+  if (!is.null(analysisSpecs$syntenyLineType)) {
     checkIREquality(gbkData, quadripRegions, tmpDir, sampleName)
   }
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -370,7 +370,7 @@ validateColors <- function(colorsToValidate) {
 }
 
 checkFeatureQualifiers <- function(sampleDF, analysisSpecs) {
-  subsetData <- getSubsetData(sampleDF, subsetCols, analysisSpecs)
+  subsetData <- getSubsetData(sampleDF, analysisSpecs)
   if (length(subsetData$missingCols) > 0) {
     logger::log_warn(paste0("Unable to analyze sample as specified; ",
                             "missing feature qualifiers: ",

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -395,3 +395,11 @@ isIgnoredFeature <- function(featureName) {
   ignoredFeatures <- c("D-loop")
   return(featureName %in% ignoredFeatures)
 }
+
+getAnalysisSpecs <- function(IRCheck) {
+  analysisSpecs <- c(
+    syntenyLineType = getSyntenyLineType(IRCheck),
+    isIRCheck = getIsIRCheck(IRCheck)
+  )
+  return(analysisSpecs)
+}

--- a/inst/extdata/PACVr_Rscript.R
+++ b/inst/extdata/PACVr_Rscript.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env RScript
 #contributors=c("Gregory Smith", "Nils Jenke", "Michael Gruenstaeudl")
 #email="m_gruenstaeudl@fhsu.edu"
-#version="2024.02.02.2100"
+#version="2024.02.05.2100"
 
 library("optparse")
 
@@ -75,7 +75,7 @@ CmdLineArgs <- function() {
                               dest    = "verbose",
                               help    = paste("a boolean, that when TRUE, generates additional files with",
                                               "detailed genomic region information;",
-                                              "requires a `regionsCheck` value that will perform region analysis"),
+                                              "requires a `IRCheck` value that will perform region analysis"),
                               metavar = "logical"),
                   make_option(opt_str = c("-o","--output"), 
                               type    = "character", 


### PR DESCRIPTION
In an attempt to reduce the complexity present in `PACVr.complete`, code responsible for producing an individual variable is present as its own function within `PACVr.R`. For similar reasons, the bulk of the code for `PACVr.verboseInformation` has been moved to `helpers.R`. Related to this goal of better clarity, the parameter of `PACVR.complete` `IRCheck` is decoded into a single variable, which can then be passed accordingly and have its elements be accessed as needed.

To address variances in GenBank data, specifically regarding which qualifier is used to detail inverted repeat names,  additional checks within `checkFeatureQualifiers` are performed.