### PR TITLE
Introduction of verbose coverage summaries

### DIFF
--- a/R/read.gb2PACVr.R
+++ b/R/read.gb2PACVr.R
@@ -72,7 +72,7 @@ checkFeatureQualifiers <- function(sampleDF, analysisSpecs) {
     logger::log_warn(paste0("Unable to analyze sample as specified; ",
                             "missing feature qualifiers: ",
                             "'",
-                            paste(missingCols, collapse = "', '"),
+                            paste(subsetData$missingCols, collapse = "', '"),
                             "'"))
     return(NULL)
   }

--- a/R/verboseInformation.R
+++ b/R/verboseInformation.R
@@ -154,7 +154,7 @@ setLowCoverage <- function(covData) {
   # ir_regions
   ir_regions <- covData$ir_regions
   regions_name <- covData$regions_name
-  aggFormula <- as.formula(paste("coverage ~", regions_name))
+  aggFormula <- stats::as.formula(paste("coverage ~", regions_name))
   cov_regions <-
     aggregate(
       aggFormula,

--- a/R/verboseInformation.R
+++ b/R/verboseInformation.R
@@ -227,6 +227,8 @@ getCovDepths <- function(covData, regions_name) {
 }
 
 getCovDepth <- function(covDataField, regions_name) {
+  lowCoverage <- NULL
+
   covDepth <- covDataField %>%
     groupByRegionsName(regions_name) %>%
     dplyr::summarise(
@@ -237,6 +239,8 @@ getCovDepth <- function(covDataField, regions_name) {
 }
 
 getCovEvenness <- function(covDataField, regions_name) {
+  coverage <- NULL
+
   covEvenness <- covDataField %>%
     groupByRegionsName(regions_name) %>%
     dplyr::summarise(

--- a/R/verboseInformation.R
+++ b/R/verboseInformation.R
@@ -39,6 +39,10 @@ printCovStats <- function(bamFile,
 
   # Writing values to output table
   writeCovTables(covData, sampleName, dir)
+
+  # Getting and writing summarized coverage data, grouped by `quadripRegions`
+  covSummaries <- getCovSummaries(covData)
+  writeCovSumTables(covSummaries, sampleName, dir)
 }
 
 getCovData <- function(regions, genes, analysisSpecs) {
@@ -195,4 +199,68 @@ writeVerboseTable <- function(df, sample_name, dir, fileName) {
     quote = FALSE,
     sep = "\t"
   )
+}
+
+# adapted from `nilsj9/PlastidSequenceCoverage`
+getCovSummaries <- function(covData) {
+  regions_name <- covData$regions_name
+
+  covSummaries <- getCovDepths(covData, regions_name)
+  regions_evenness <- getCovEvenness(covData$ir_regions, regions_name)
+  covSummaries$regions_summary <- dplyr::full_join(covSummaries$regions_summary,
+                                                   regions_evenness,
+                                                   regions_name)
+  return(covSummaries)
+}
+
+getCovDepths <- function(covData, regions_name) {
+  regions_depth <- getCovDepth(covData$ir_regions, regions_name)
+  genes_depth <- getCovDepth(covData$ir_genes, regions_name)
+  noncoding_depth <- getCovDepth(covData$ir_noncoding, regions_name)
+  
+  covDepths <- list(
+    regions_summary = regions_depth,
+    genes_summary = genes_depth,
+    noncoding_summary = noncoding_depth
+  )
+  return(covDepths)
+}
+
+getCovDepth <- function(covDataField, regions_name) {
+  covDepth <- covDataField %>%
+    groupByRegionsName(regions_name) %>%
+    dplyr::summarise(
+      lowCoverage = sum(lowCoverage == "*", na.rm = TRUE),
+      .groups = "drop"
+    )
+  return(covDepth)
+}
+
+getCovEvenness <- function(covDataField, regions_name) {
+  covEvenness <- covDataField %>%
+    groupByRegionsName(regions_name) %>%
+    dplyr::summarise(
+      evenness = evennessScore(coverage),
+      .groups = "drop"
+    )
+  return(covEvenness)
+}
+
+groupByRegionsName <- function(df, regions_name) {
+  return(
+    dplyr::group_by(df, dplyr::across(dplyr::all_of(regions_name)))
+  )
+}
+
+evennessScore <- function(coverage) {
+  coverage_mean <- round(mean(coverage))
+  D2 <- coverage[coverage <= coverage_mean]
+  E <- 1 - (length(D2) - sum(D2) / coverage_mean) / length(coverage)
+  return(E)
+}
+
+writeCovSumTables <- function(covSummaries, sample_name, dir) {
+  writeVerboseTable(covSummaries$genes_summary, sample_name, dir, "coverage.summary.genes")
+  writeVerboseTable(covSummaries$regions_summary, sample_name, dir, "coverage.summary.regions")
+  writeVerboseTable(covSummaries$noncoding_summary, sample_name, dir, "coverage.summary.noncoding")
 }


### PR DESCRIPTION
Using `nilsj9/PlastidSequenceCoverage` as a reference point, I implemented the creation and writing of "coverage summaries". These are referred to as "summaries" since they consist of statistics grouped by region. For now, this additional functionality of `printCovStats()` is executed automatically, after calling `writeCovTables()`. These corresponding files are housed in the same directory as the verbose files written in `writeCovTables()`, and with the name format `<sample_name>_coverage.summary.<feature_type>.tsv`.

As the name implies, I can more broadly foresee this being a repository for various coverage summary statistics, or possibly generalized to house non-coverage summary statistics as well. For now, each file has a depth metric using the counts of `lowCoverage` in the region, and for the `regions` feature type, an additional evenness score, using the function `evennessScore()` from `nilsj9/PlastidSequenceCoverage`. The choice to only have the evenness done for the region feature type reflected its application in the referenced R script.

Attached are examples of the artifacts produced by the combination of `getCovSummaries()` and `writeCovSumTables()`. They correspond to a call of `PACVr.complete()` for `NC_045072` as in the `README.md`, with parameters corresponding to `## COVERAGE VALUES PLUS REGION INDICATORS ##`, with the additional non-default value of `verbose = TRUE`. Note that they are in a `.ZIP` file since GitHub does not support `.tsv`.

[NC_045072.1_coverage.summary.zip](https://github.com/michaelgruenstaeudl/PACVr/files/14250403/NC_045072.1_coverage.summary.zip)